### PR TITLE
Blocking scheme sampling

### DIFF
--- a/halmd/observables/dynamics/blocking_scheme.hpp
+++ b/halmd/observables/dynamics/blocking_scheme.hpp
@@ -119,6 +119,8 @@ public:
         return time_;
     }
 
+    step_type next() const;
+
     /** Lua bindings */
     static void luaopen(lua_State* L);
 

--- a/lua/halmd/observables/dynamics/blocking_scheme.lua.in
+++ b/lua/halmd/observables/dynamics/blocking_scheme.lua.in
@@ -1,5 +1,6 @@
 --
 -- Copyright © 2011-2014 Felix Höfling
+-- Copyright © 2015      Nicolas Höft
 -- Copyright © 2011-2012 Peter Colberg
 --
 -- This file is part of HALMD.
@@ -123,13 +124,15 @@ local M = module(function(args)
         local conn = {}
         result.disconnect = utility.signal.disconnect(conn, "correlation function")
 
-        -- establish internal connections of the correlation function
-        -- e.g., particle:enable_aux() → sampler.on_prepare_force,
-        -- and append to our connection table
-        if tcf.connect then
-            conn_ = tcf:connect({every = every}) -- FIXME pass actual grid of sampling steps
-            for i,c in ipairs(conn_) do
-                table.insert(conn, c)
+        -- enable auxiliary variable calculation, if necessary for correlation function
+        if tcf.aux_enable then
+            local particles = utility.assert_type(tcf.aux_enable, "table")
+            for i,p in ipairs(particles) do
+                table.insert(conn, sampler:on_prepare(function()
+                    if self:next() == clock.step then
+                        p:aux_enable()
+                    end
+                end, 1, clock.step))
             end
         end
 

--- a/lua/halmd/observables/dynamics/correlation.lua.in
+++ b/lua/halmd/observables/dynamics/correlation.lua.in
@@ -83,6 +83,7 @@ local blocking_scheme_adaptor = assert(libhalmd.observables.samples.blocking_sch
 -- :param args.location: default location within file
 -- :type args.location: string table
 -- :param string args.desc: module description
+-- :param table args.aux_enable: sequence of :class:`halmd.mdsim.particle` instances *(optional)*
 --
 -- The argument ``acquire`` is a callable or a table of up to 2 callables that
 -- yield the samples to be correlated.
@@ -94,6 +95,13 @@ local blocking_scheme_adaptor = assert(libhalmd.observables.samples.blocking_sch
 -- The argument ``location`` defines the default value of ``writer()``. For
 -- H5MD files, it obeys the structure {``"dynamics"``, particle group, name of
 -- correlation function}.
+--
+-- The parameter ``aux_enable`` is useful if ``acquire()`` depends on one of
+-- the auxiliary force variables, see :meth:`halmd.mdsim.particle.aux_enable`
+-- for details. In sampling steps of the correlation function, each ``particle``
+-- instance listed in ``aux_enable`` is notified to update the auxiliary
+-- variables before the sampling step. Thereby, redundant force calculations
+-- can be avoided.
 --
 -- .. method:: acquire()
 --
@@ -112,6 +120,11 @@ local blocking_scheme_adaptor = assert(libhalmd.observables.samples.blocking_sch
 -- .. attribute:: desc
 --
 --    Module description.
+--
+-- .. attribute:: aux_enable
+--
+--    Sequence of particle instances that require auxiliary variables
+--    during sampling.
 --
 -- .. class:: writer(args)
 --
@@ -133,6 +146,7 @@ local M = module(function(args)
     local shape     = utility.assert_type(args.shape or {}, "table")
     local location  = utility.assert_type(utility.assert_kwarg(args, "location"), "table")
     local desc      = utility.assert_type(utility.assert_kwarg(args, "desc"), "string")
+    local aux_enable = utility.assert_type(args.aux_enable or {}, "table")
 
     -- ensure that acquire is a table
     if not (type(acquire) == "table") then
@@ -164,6 +178,10 @@ local M = module(function(args)
         local writer = file:writer({location = location, mode = "truncate"})
         return writer
     end end)
+
+    self.aux_enable = property(function(self)
+        return aux_enable
+    end)
 
     return self
 end)

--- a/lua/halmd/observables/dynamics/stress_tensor_autocorrelation.lua.in
+++ b/lua/halmd/observables/dynamics/stress_tensor_autocorrelation.lua.in
@@ -1,5 +1,5 @@
 --
--- Copyright © 2013      Nicolas Höft
+-- Copyright © 2013-2015 Nicolas Höft
 -- Copyright © 2013-2014 Felix Höfling
 --
 -- This file is part of HALMD.
@@ -82,19 +82,6 @@ local sampler     = require("halmd.observables.sampler")
 --
 --    Module description.
 --
--- .. method:: connect(args)
---
---    :param table args: keyword arguments
---    :param args.every: sampling interval
---    :returns: sequence of signal connections
---
---    *Internal use only.* This function is called upon registration by
---    ``blocking_scheme:correlation()``.
---
---    Connect ``msv.group.particle:aux_enable()`` to the signal
---    ``on_prepend_force`` of :class:`halmd.observables.sampler` using the
---    interval ``every``.
---
 -- .. class:: writer(args)
 --
 --    Construct file writer.
@@ -136,16 +123,8 @@ local M = module(function(args)
       , location = {"dynamics", label, "stress_tensor_autocorrelation"}
         -- module description
       , desc = ("stress tensor autocorrelation of %s particles"):format(label)
+      , aux_enable = {msv.group.particle}
     }))
-
-    self.connect = function(self, args)
-        local every = utility.assert_kwarg(args, "every")
-
-        local conn = {
-            assert(sampler:on_prepare(function() msv.group.particle:aux_enable() end, every, clock.step))
-        }
-        return conn
-    end
 
     return self
 end)


### PR DESCRIPTION
This is an attempt to fix the problem discussed in ticket #282179. I've added a function that is able to calculate the next sampling step for the blocking scheme, which then can be used to enable the auxiliary variables only if required (e.g. for the stress tensor autocorrelation).

This moves the `aux_enable()` logic out of the tcf and into the blocking scheme, but the tcf holds the information about whether auxiliary variables are calculated or not.

blocking_scheme::next() could maybe optimized by recalculating the next sampling step only if the last old one has been reached (ie if `clock->step()` > last returned value from `next()` )
